### PR TITLE
Use Webpack new .hooks API to remove deprecation warning.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var DtsBundlePlugin = (function () {
     DtsBundlePlugin.prototype.apply = function (compiler) {
         const _this = this;
 
-        compiler.plugin('done', function() {
+        compiler.hooks.done.tap({ name: 'DtsBundlePlugin' }, function() {
             dts.bundle(_this.options);
         });
     };


### PR DESCRIPTION
Webpack deprecated usage of `compiler.plugin` for `compiler.hooks`.

This PR uses the new `.hooks` API, and removes current error message present in each build:

```
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```
